### PR TITLE
stream_cdda: stop suppressing -Wscript-prototypes

### DIFF
--- a/stream/stream_cdda.c
+++ b/stream/stream_cdda.c
@@ -23,12 +23,8 @@
 
 #include <cdio/cdio.h>
 
-// For cdio_cddap_version
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-prototypes"
 #include <cdio/paranoia/cdda.h>
 #include <cdio/paranoia/paranoia.h>
-#pragma GCC diagnostic pop
 
 #include "common/msg.h"
 #include "config.h"


### PR DESCRIPTION
This was fixed upstream* so it's no longer needed.

*: https://github.com/rocky/libcdio-paranoia/commit/3ced3d72debae3cf304c81be820356c336fd31a2